### PR TITLE
style: button background should follow MSM styling

### DIFF
--- a/MarvalSoftware.Plugins.Jira.html
+++ b/MarvalSoftware.Plugins.Jira.html
@@ -172,7 +172,6 @@
                     width: 80px;
                     border: 1px solid #CCC;
                     border-radius: 2px;
-                    background: #F5F5F5;
                     bottom: 28px;
                 }
 


### PR DESCRIPTION
The styling of the create button contained a hardcoded background
colour which would override the button background colour as set up
in MSM's style sheet settings. This could result in an unreadable
button if the default button text were white(ish).

This commit removes the hardcoded background colour value.